### PR TITLE
Removing CAGE

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -66,7 +66,6 @@
 	<h2>Gameplay</h2>
 	<ul>
 		<li><button onclick='mod(36744)'>Armour Repair Kits</button></li>
-		<li><button onclick='mod(42428)'>CAGE - Game Continues After Game Ends</button></li>
 		<li><button onclick='mod(66726)'>FPGE - Functional Post Game Ending</button></li>
 		<li><button onclick='mod(66832)'>Container Respawns Warning</button></li>
 		<li><button onclick='mod(44569)'>Daily Vendor Restock</button></li>


### PR DESCRIPTION
Removing CAGE because as stated on the mod page of FPGE, "For obvious reasons, do not run this mod alongside any other 'Continue after the ending' mods".